### PR TITLE
add example overpass query for museums in and around London.

### DIFF
--- a/overpass_query.txt
+++ b/overpass_query.txt
@@ -1,0 +1,19 @@
+<union>
+    <query type="node">
+		<has-kv k="tourism" v="museum"/>
+  		<bbox-query s="51.22924786327828" w="-0.613861083984375" n="51.705757442694036" e="0.416107177734375"/>
+    </query>
+    <query type="way">
+  		<has-kv k="tourism" v="museum"/>
+  		<bbox-query s="51.22924786327828" w="-0.613861083984375" n="51.705757442694036" e="0.416107177734375"/>
+    </query>
+    <query type="relation">
+  		<has-kv k="tourism" v="museum"/>
+  		<bbox-query s="51.22924786327828" w="-0.613861083984375" n="51.705757442694036" e="0.416107177734375"/>
+    </query>
+  </union>
+<union>
+  <item/>
+  <recurse type="down"/>
+</union>
+<print/>


### PR DESCRIPTION
[Overpass](http://overpass-api.de/) is a nice API for querying all of OSM. You can paste this query `overpass_query.txt` into the [Overpass Turbo](http://overpass-turbo.eu/) user interface and get all entities that are tagged `tourism=museum`:

![screen shot 2014-08-02 at 7 13 04 pm](https://cloud.githubusercontent.com/assets/77501/3789644/3bb66b8e-1ab4-11e4-92ba-309be4c9c7ea.png)

I've chosen an arbitrary bounding box in the query that includes London and surrounding areas. Of the results, some museums are tagged as one-dimensional _nodes_, others have building outlines:

![screen shot 2014-08-02 at 7 13 26 pm](https://cloud.githubusercontent.com/assets/77501/3789645/4ad91382-1ab4-11e4-82f0-ac43b64aa1d2.png)

Inside Overpass Turbo you can also go to `Export > As GeoJSON...` to get a file that you can manipulate in other programs.
